### PR TITLE
Kp plant input checks

### DIFF
--- a/actions/add_plant.py
+++ b/actions/add_plant.py
@@ -46,6 +46,7 @@ def add_plant(arboretum):
         print("2. Silversword")
         print("3. Rainbow Eucalyptus Tree")
         print("4. Blue Jade Vine")
+        print("0. Return to main menu")
         
         #Present and handle choice
         choice = input("Choose plant to cultivate > ")
@@ -61,6 +62,9 @@ def add_plant(arboretum):
         
         elif choice == "4":
             plant = BlueJadeVine()
+            
+        elif choice == "0":
+            return 0
             
         else: 
             input(f"Choose a valid option. Hit ENTER to try again. >")
@@ -101,8 +105,11 @@ def add_plant(arboretum):
         
         choice = input(f"Choose environment to plant {plant_instance} > ")
         # If choice is not an integer, it will trigger the exception
+        if choice == "0":
+            return 0
         try: 
             index = int(choice) - 1
+            # If index is between 0 and 1- the list length:
             #Checking if the choice is within the correct index range:
             if index >= 0 and index < len(possible_environ_instances):
                 # Choose the matching environment index

--- a/actions/add_plant.py
+++ b/actions/add_plant.py
@@ -51,36 +51,50 @@ def add_plant(arboretum):
         #Present and handle choice
         choice = input("Choose plant to cultivate > ")
         plant = ""
-        if choice == "1":
-            plant = MountainAppleTree()
-        
-        elif choice == "2":
-            plant = Silversword()
-        
-        elif choice == "3":
-            plant = RainbowEucalyptusTree()    
-        
-        elif choice == "4":
-            plant = BlueJadeVine()
-            
-        elif choice == "0":
-            return 0
-            
-        else: 
+        # If choice is not an integer, it will be handled by the except:
+        try:
+            choice = int(choice)
+            # This should not really be a hard-coded range,
+            # but for the purposes of this exercise, it won't change
+            if choice >= 0 and choice <= 4:
+                if choice == 1:
+                    plant = MountainAppleTree()
+                
+                elif choice == 2:
+                    plant = Silversword()
+                
+                elif choice == 3:
+                    plant = RainbowEucalyptusTree()    
+                
+                elif choice == 4:
+                    plant = BlueJadeVine()
+                    
+                elif choice == 0:
+                    return 0
+                
+                else:
+                    input("There are no appropriate environments for that plant. Press ENTER to choose a new plant. > ")
+                    step_one()
+                
+                #build a list of environment appropriate environ instances    
+                environs = determine_environs(plant)
+                
+                # move on to step two, with 
+                # the appropriate environ instances 
+                # and selected plant instance 
+                if len(environs) > 0:       
+                    step_two(environs, plant) 
+                else:
+                    input("There are no appropriate environments for that plant. Press ENTER to choose a new plant. > ")
+                    step_one()
+            else:
+                input(f"Choose a valid option. Hit ENTER to try again. >") 
+                step_one()
+                
+        except ValueError: 
             input(f"Choose a valid option. Hit ENTER to try again. >")
             step_one()
         
-        #build a list of environment appropriate environ instances    
-        environs = determine_environs(plant)
-        
-        # move on to step two, with 
-        # the appropriate environ instances 
-        # and selected plant instance 
-        if len(environs) > 0:       
-            step_two(environs, plant) 
-        else:
-            input("There are no appropriate environments for that plant. Press ENTER to choose a new plant. > ")
-            step_one()
                 
     # Choosing an environment for the plant        
     def step_two(list_of_instance_lists, plant_instance): 

--- a/actions/add_plant.py
+++ b/actions/add_plant.py
@@ -102,6 +102,7 @@ def add_plant(arboretum):
                     
         build_instance_list()
         print_instance_list()
+        print("0. Return to main menu")
         
         choice = input(f"Choose environment to plant {plant_instance} > ")
         # If choice is not an integer, it will trigger the exception

--- a/actions/add_plant.py
+++ b/actions/add_plant.py
@@ -63,6 +63,7 @@ def add_plant(arboretum):
             plant = BlueJadeVine()
             
         else: 
+            input(f"Choose a valid option. Hit ENTER to try again. >")
             step_one()
         
         #build a list of environment appropriate environ instances    
@@ -81,6 +82,7 @@ def add_plant(arboretum):
     def step_two(list_of_instance_lists, plant_instance): 
         os.system('cls' if os.name == 'nt' else 'clear')
         header(title)
+        # Start an empty list to put the environments in
         possible_environ_instances = []      
             
         def build_instance_list():
@@ -98,11 +100,17 @@ def add_plant(arboretum):
         print_instance_list()
         
         choice = input(f"Choose environment to plant {plant_instance} > ")
+        #TODO: add check to see if its an integer
         index = int(choice) - 1 
-        environment = possible_environ_instances[index]
-        confirm = input(f"Add {plant_instance} to {environment}: y/n? > ")
-        if confirm == "y":
-            environment.add_plant(plant_instance)
-            print(f"{plant_instance} added to {environment}")
+        #Checking if the choice is within the correct index range:
+        if index > 0 and index < len(possible_environ_instances):
+            environment = possible_environ_instances[index]
+            confirm = input(f"Add {plant_instance} to {environment}: y/n? > ")
+            if confirm == "y":
+                environment.add_plant(plant_instance)
+                print(f"{plant_instance} added to {environment}")
+        else:
+            input(f"Choose a valid option. Hit ENTER to try again. >")
+            step_two(list_of_instance_lists, plant_instance)
         
     step_one()

--- a/actions/add_plant.py
+++ b/actions/add_plant.py
@@ -100,17 +100,25 @@ def add_plant(arboretum):
         print_instance_list()
         
         choice = input(f"Choose environment to plant {plant_instance} > ")
-        #TODO: add check to see if its an integer
-        index = int(choice) - 1 
-        #Checking if the choice is within the correct index range:
-        if index > 0 and index < len(possible_environ_instances):
-            environment = possible_environ_instances[index]
-            confirm = input(f"Add {plant_instance} to {environment}: y/n? > ")
-            if confirm == "y":
-                environment.add_plant(plant_instance)
-                print(f"{plant_instance} added to {environment}")
-        else:
+        # If choice is not an integer, it will trigger the exception
+        try: 
+            index = int(choice) - 1
+            #Checking if the choice is within the correct index range:
+            if index >= 0 and index < len(possible_environ_instances):
+                # Choose the matching environment index
+                environment = possible_environ_instances[index]
+                confirm = input(f"Add {plant_instance} to {environment}: y/n? > ")
+                if confirm == "y":
+                    environment.add_plant(plant_instance)
+                    print(f"{plant_instance} added to {environment}")
+                else:
+                    step_two(list_of_instance_lists, plant_instance)
+            else:
+                input(f"Choose a valid option. Hit ENTER to try again. >")
+                step_two(list_of_instance_lists, plant_instance)
+        except ValueError:
             input(f"Choose a valid option. Hit ENTER to try again. >")
             step_two(list_of_instance_lists, plant_instance)
+
         
     step_one()

--- a/actions/header.py
+++ b/actions/header.py
@@ -20,6 +20,6 @@ def header(text):
         return spaced_str
     
     print(center("+-++-++-++-++-++-++-++-++-++-++-++-++-++-++-++-++-+"))
-    print(space_out(text))
+    print(center(space_out(text)))
     print(center("+-++-++-++-++-++-++-++-++-++-++-++-++-++-++-++-++-+"))
     print()


### PR DESCRIPTION
`add_plant` now has:
- more thorough input checking
- "return to main menu" zero option on both steps

Header minor update as well, to get the text centered.

1. `git checkout master`
1. `git fetch --all`
1. `git checkout kp-plant-input-checks`
1. `python index.py`
1. "Secret 7"
1. 4 to go to add plant menu

Confirm:
1. 0. Return to main option on all steps of add_plant
1. Incorrect inputs are all properly handled: (like strings and out-of-index numbers).  